### PR TITLE
WW3 input file reorganize..

### DIFF
--- a/Shell/couple.sh
+++ b/Shell/couple.sh
@@ -154,6 +154,13 @@ time_start0=$(date "+%s")
 if [ $parameter_ROMS2WRF = yes ]; then
 echo "ROMS2WRF: NHour=$NHour, NLOOP=$NLOOP, $YYYYi:$MMi:$DDi:$HHi"
 
+        grep "failed" $logfile
+        if [ $? -eq 0 ]; then
+        echo "ERROR: reading or writing failed: ROMS2WRF.sh"
+        else
+        echo "no ERROR"
+        exit 8
+
 time_start=$(date "+%s")
 $Couple_Run_Dir/ROMS2WRF.sh $NHour $YYYYi:$MMi:$DDi:$HHi $YYYYin:$MMin:$DDin:$HHin $CF $NLOOP $NHourm || exit 8
 time_end=$(date "+%s")
@@ -173,6 +180,14 @@ echo "WW32WRF: NHour=$NHour, NLOOP=$NLOOP, $YYYYi:$MMi:$DDi:$HHi ~ $YYYYin:$MMin
 
 time_start=$(date "+%s")
 	$Couple_Run_Dir/WW32WRF.sh $NHour $NHourm $CF $NLOOP $YYYYin:$MMin:$DDin:$HHin  || exit 8
+
+        grep "failed" $logfile
+        if [ $? -eq 0 ]; then
+        echo "ERROR: reading or writing failed: WW32WRF.sh"
+        else
+        echo "no ERROR"
+        exit 8
+
 time_end=$(date "+%s")
 echo "WW32WRF = $((time_end-time_start))s" >> $Couple_Run_Dir/code_time
 

--- a/main_scripts/example/example1/main_example1_r01.sh
+++ b/main_scripts/example/example1/main_example1_r01.sh
@@ -293,7 +293,12 @@ export WW3_spinup=no
         echo "doesn't exist: $WW3_ICFile or $WW3_ICFile_NC"
         exit 8
         fi
-	
+
+        export WW3_BCFile=/projects/owrs/hseo/SCOAR_WFP2/Data/domains/$gridname2/$gridname\_DJFM_2016_2017/WW3_Input/nest.ww3_DJFM_2016_2017
+        if [ ! -s $WW3_BCFile ]; then
+        echo "doesn't exist: $WW3_BCFile"
+        exit 8
+        fi
 fi
 
 # Main Run Directory
@@ -565,7 +570,12 @@ fi
 
 # WW3 executables
 ln -fs $Couple_Lib_exec_WW3_Dir/exec/$WW3_exe_Filename $WW3_Exe_Dir || exit 8
-ln -fs $Couple_Lib_grids_WW3_Dir/*ww3 $WW3_Exe_Dir || exit 8
+ln -fs $Couple_Lib_grids_WW3_Dir/mod_def.ww3 $WW3_Exe_Dir || exit 8
+ln -fs $Couple_Lib_grids_WW3_Dir/mapsta.ww3 $WW3_Exe_Dir || exit 8
+ln -fs $Couple_Lib_grids_WW3_Dir/mask.ww3 $WW3_Exe_Dir || exit 8
+
+# WW3 BCFile
+ln -fs $WW3_BCFile $WW3_Exe_Dir/nest.ww3 || exit 8
 
 # WW3 namelist only what isused...
 cp     $Couple_Lib_exec_WW3_Dir/ww3_prnc_wind.nml    $WW3_Exe_Dir || exit 8

--- a/main_scripts/example/example1/submit_main_example1_r01a_poseidon.sh
+++ b/main_scripts/example/example1/submit_main_example1_r01a_poseidon.sh
@@ -25,4 +25,5 @@ mme=11
 dde=12
 hhe=00
 
-$scoar_dir/main_nep1_r01.sh $yyyye:$mme:$dde:$hhe $RESTART $LastNHour >& r01_log_$$_$yyyye$mme$dde$hhe
+export logfile=/vortexfs1/share/seolab/hseo/SCOAR_git/SCOAR/main_scripts/example/example1/r01_log_$$_$yyyye$mme$dde$hhe
+$scoar_dir/main_nep1_r01.sh $yyyye:$mme:$dde:$hhe $RESTART $LastNHour >&  $logfile


### PR DESCRIPTION
1. For WW3, nest.ww3 (boundary file) should reside in Data/WW3_Input. The modified main script looks for WW3_BCFile (as is done with WW3_ICFile).

2 Also specify the names of the WW3 executables (mod_def.ww3, mapsta.ww3, and mask.ww3) to link.