### PR TITLE
Error handling

### DIFF
--- a/Lib/codes_intel/calculate_WRF_flux_nobulk_prec_acc.f
+++ b/Lib/codes_intel/calculate_WRF_flux_nobulk_prec_acc.f
@@ -280,6 +280,6 @@
          print *, n,' ',status
          print *, 'reading angle from ROMS grid file failed!!!'
          print *, 'stop'
-          call exit
+         stop status
       endif
       end subroutine handle_err

--- a/Lib/codes_intel/calculate_WRF_flux_nobulk_prec_acc_tauoc.f
+++ b/Lib/codes_intel/calculate_WRF_flux_nobulk_prec_acc_tauoc.f
@@ -344,6 +344,6 @@
          print *, n,' ',status
          print *, 'reading angle from ROMS grid file failed!!!'
          print *, 'stop'
-          call exit
+         stop status
       endif
       end subroutine handle_err

--- a/Lib/codes_intel/filt2d.f
+++ b/Lib/codes_intel/filt2d.f
@@ -255,7 +255,7 @@
          print *, 'failed! nc file not read correctly ',Num
          print *, '*****************************'
          print *, 'stop'
-          stop
+         stop status
       endif
       end subroutine
 

--- a/Lib/codes_intel/filt2d_use_qck.f
+++ b/Lib/codes_intel/filt2d_use_qck.f
@@ -253,7 +253,7 @@
          print *, 'failed! nc file not read correctly ',Num
          print *, '*****************************'
          print *, 'stop'
-          stop
+         stop status
       endif
       end subroutine
 

--- a/Lib/codes_intel/read_ncvar.f
+++ b/Lib/codes_intel/read_ncvar.f
@@ -89,6 +89,6 @@
           print *, n,' ',status
           print *, 'reading variable from wrfout.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/sst_wrflowinp.f
+++ b/Lib/codes_intel/sst_wrflowinp.f
@@ -138,6 +138,6 @@
           print *, n,' ',status
           print *, 'reading sst from avg.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/sst_wrflowinp_nolake_initial.f
+++ b/Lib/codes_intel/sst_wrflowinp_nolake_initial.f
@@ -171,6 +171,6 @@
           print *, n,' ',status
           print *, 'reading sst from avg.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/sst_wrflowinp_nolake_perf_rst.f
+++ b/Lib/codes_intel/sst_wrflowinp_nolake_perf_rst.f
@@ -95,28 +95,28 @@
 ! #######################################################
 ! read sst value first 
       status = nf_open('fort.14',nf_nowrite,ncid2)
-      if (status .ne. nf_noerr) call handle_err(status,7)
+      if (status .ne. nf_noerr) call handle_err(status,5)
 
       status = nf_inq_varid(ncid2,'SST',varid2)
-      if (status .ne. nf_noerr) call handle_err(status,8)
+      if (status .ne. nf_noerr) call handle_err(status,6)
       status=nf_get_vars_double(ncid2,varid2,
      &               start2,count2,stride2,sstWRF)
-      if (status .ne. nf_noerr) call handle_err(status,10)
+      if (status .ne. nf_noerr) call handle_err(status,7)
 
       status = nf_close(ncid2)
-      if (status .ne. nf_noerr) call handle_err(status,12)
+      if (status .ne. nf_noerr) call handle_err(status,8)
 ! ###########
 
 ! read landmask WRF
 ! #######################################################
       status = nf_open('fort.166',nf_nowrite,ncid2)
-      if (status .ne. nf_noerr) call handle_err(status,7)
+      if (status .ne. nf_noerr) call handle_err(status,9)
 
       status = nf_inq_varid(ncid2,'LANDMASK',varid2)
-      if (status .ne. nf_noerr) call handle_err(status,8)
+      if (status .ne. nf_noerr) call handle_err(status,10)
       status=nf_get_vars_double(ncid2,varid2,
      &               start3,count2,stride2,land_wrf)
-      if (status .ne. nf_noerr) call handle_err(status,10)
+      if (status .ne. nf_noerr) call handle_err(status,11)
 
       status = nf_close(ncid2)
       if (status .ne. nf_noerr) call handle_err(status,12)
@@ -125,16 +125,16 @@
 ! read lakemask WRF
 ! #######################################################
       status = nf_open('fort.166',nf_nowrite,ncid2)
-      if (status .ne. nf_noerr) call handle_err(status,7)
+      if (status .ne. nf_noerr) call handle_err(status,13)
 
       status = nf_inq_varid(ncid2,'LAKEMASK',varid2)
-      if (status .ne. nf_noerr) call handle_err(status,8)
+      if (status .ne. nf_noerr) call handle_err(status,14)
       status=nf_get_vars_double(ncid2,varid2,
      &               start3,count2,stride2,lake_wrf)
-      if (status .ne. nf_noerr) call handle_err(status,10)
+      if (status .ne. nf_noerr) call handle_err(status,15)
 
       status = nf_close(ncid2)
-      if (status .ne. nf_noerr) call handle_err(status,12)
+      if (status .ne. nf_noerr) call handle_err(status,16)
 ! ###########
 
 ! treat land/mask
@@ -153,20 +153,20 @@
 ! write to wrflowinp
 ! 1. open forc file
       status = nf_open('fort.14',nf_write,ncid2)
-      if (status .ne. nf_noerr) call handle_err(status,7)
+      if (status .ne. nf_noerr) call handle_err(status,17)
 
 ! 2. get varid from forc file
       status = nf_inq_varid(ncid2,'SST',varid2)
-      if (status .ne. nf_noerr) call handle_err(status,8)
+      if (status .ne. nf_noerr) call handle_err(status,18)
 
 ! 3.  write SST
       status=nf_put_vars_double(ncid2,varid2,
      &               start2,count2,stride2,sstROMS)
-      if (status .ne. nf_noerr) call handle_err(status,10)
+      if (status .ne. nf_noerr) call handle_err(status,19)
 
 ! 4. close 
       status = nf_close(ncid2)
-      if (status .ne. nf_noerr) call handle_err(status,12)
+      if (status .ne. nf_noerr) call handle_err(status,20)
 ! ###########
      
       call exit
@@ -178,6 +178,6 @@
           print *, n,' ',status
           print *, 'reading sst from rst.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/sst_wrflowinp_nolake_smooth.f
+++ b/Lib/codes_intel/sst_wrflowinp_nolake_smooth.f
@@ -122,6 +122,6 @@
           print *, n,' ',status
           print *, 'reading sst from avg.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/sst_wrflowinp_nolake_use_qck.f
+++ b/Lib/codes_intel/sst_wrflowinp_nolake_use_qck.f
@@ -166,6 +166,6 @@
           print *, n,' ',status
           print *, 'reading sst from avg.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/sst_wrflowinp_use_qck.f
+++ b/Lib/codes_intel/sst_wrflowinp_use_qck.f
@@ -136,6 +136,6 @@
           print *, n,' ',status
           print *, 'reading sst from avg.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/uauo.f
+++ b/Lib/codes_intel/uauo.f
@@ -240,6 +240,6 @@
           print *, n,' ',status
           print *, 'reading uv @ sfc from forc.nc failed!!!'
           print *, 'stop'
-          call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/uauo_smooth.f
+++ b/Lib/codes_intel/uauo_smooth.f
@@ -286,6 +286,6 @@
           print *, n,' ',status
           print *, 'reading uv @ sfc from forc.nc failed!!!'
           print *, 'stop'
-          call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/uauo_use_qck_20190604.f
+++ b/Lib/codes_intel/uauo_use_qck_20190604.f
@@ -191,6 +191,6 @@
           print *, n,' ',status
           print *, 'reading uv @ sfc from forc.nc failed!!!'
           print *, 'stop'
-          call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/update_bry_time3.f
+++ b/Lib/codes_intel/update_bry_time3.f
@@ -43,6 +43,6 @@
          print *, 'failed! update time on bry.nc ',Num
          print *, '*****************************'
          print *, 'stop'
-          call exit
+         stop status
       endif
       end subroutine handle_err

--- a/Lib/codes_intel/update_forc.f
+++ b/Lib/codes_intel/update_forc.f
@@ -67,6 +67,6 @@
          print *, 'failed! update forc.nc ',Num
          print *, '*****************************'
          print *, 'stop'
-          call exit
+         stop status
       endif
       end subroutine handle_err

--- a/Lib/codes_intel/update_forc_time3.f
+++ b/Lib/codes_intel/update_forc_time3.f
@@ -48,6 +48,6 @@
          print *, 'failed! update time on forc.nc ',Num
          print *, '*****************************'
          print *, 'stop'
-          call exit
+         stop status
       endif
       end subroutine handle_err

--- a/Lib/codes_intel/update_init3D.f
+++ b/Lib/codes_intel/update_init3D.f
@@ -66,7 +66,7 @@
           print *, '*****************************'
           print *, 'failed! update init ', Num
           print *, '*****************************'
-           call exit
+          stop status
        endif
        end subroutine handle_err
 

--- a/Lib/codes_intel/update_init4D.f
+++ b/Lib/codes_intel/update_init4D.f
@@ -77,7 +77,7 @@
           print *, '*****************************'
           print *, 'failed! update init: ',Num
           print *, '*****************************'
-           call exit
+          stop status
        endif
        end subroutine handle_err
 

--- a/Lib/codes_intel/update_init_time3.f
+++ b/Lib/codes_intel/update_init_time3.f
@@ -46,6 +46,6 @@
          print *, 'failed! update time on forc.nc ',Num
          print *, '*****************************'
          print *, 'stop'
-          call exit
+         stop status
       endif
       end subroutine handle_err

--- a/Lib/codes_intel/uvoce_wrflowinp_nolake_initial.f
+++ b/Lib/codes_intel/uvoce_wrflowinp_nolake_initial.f
@@ -266,6 +266,6 @@
           print *, n,' ',status
           print *, 'reading uoce/voce from IC file failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/uvoce_wrflowinp_nolake_perf_rst.f
+++ b/Lib/codes_intel/uvoce_wrflowinp_nolake_perf_rst.f
@@ -269,6 +269,6 @@
           print *, n,' ',status
           print *, 'reading uoce/voce from rst.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/uvoce_wrflowinp_nolake_use_qck.f
+++ b/Lib/codes_intel/uvoce_wrflowinp_nolake_use_qck.f
@@ -219,6 +219,6 @@
           print *, n,' ',status
           print *, 'reading uoce from qck.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/ww3_dp_wrflowinp.f
+++ b/Lib/codes_intel/ww3_dp_wrflowinp.f
@@ -153,6 +153,6 @@
           print *, n,' ',status
           print *, 'reading dp from ww3.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/ww3_fp_wrflowinp.f
+++ b/Lib/codes_intel/ww3_fp_wrflowinp.f
@@ -112,6 +112,6 @@
           print *, n,' ',status
           print *, 'reading fp from ww3.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/ww3_hs_wrflowinp.f
+++ b/Lib/codes_intel/ww3_hs_wrflowinp.f
@@ -104,6 +104,6 @@
           print *, n,' ',status
           print *, 'reading hs from ww3.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/ww3_t02_wrflowinp.f
+++ b/Lib/codes_intel/ww3_t02_wrflowinp.f
@@ -104,6 +104,6 @@
           print *, n,' ',status
           print *, 'reading t02 from ww3.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/ww3_t0m1_wrflowinp.f
+++ b/Lib/codes_intel/ww3_t0m1_wrflowinp.f
@@ -104,6 +104,6 @@
           print *, n,' ',status
           print *, 'reading t0m1 from ww3.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Lib/codes_intel/ww3_ust_wrflowinp.f
+++ b/Lib/codes_intel/ww3_ust_wrflowinp.f
@@ -146,6 +146,6 @@
           print *, n,' ',status
           print *, 'reading ust from ww3.nc failed!!!'
           print *, 'stop'
-           call exit
+          stop status
        endif
        end subroutine handle_err

--- a/Shell/ROMS2WRF.sh
+++ b/Shell/ROMS2WRF.sh
@@ -202,11 +202,11 @@ if [ $NOLAKE = yes ]; then
         fi
     elif [ $NLOOP -eq 1 -a $ROMS_PERFECT_RESTART = yes ]; then
         # for initial SST update, since it is usually ROMS IC, don't use use_qck.
-		$Couple_Lib_exec_coupler_Dir/sst_wrflowinp_nolake_roms_perf_rst.x || exit 8
+		$Couple_Lib_exec_coupler_Dir/sst_wrflowinp_nolake_perf_rst.x || exit 8
 		if [ $UaUo = yes ]; then
 		    echo UaUo is yes: uoce/voce in wrflowinp will be updated
 			# need to convert u/v from u/v-grid of the ROMS ICfile to rho grid ...
-            $Couple_Lib_exec_coupler_Dir/uvoce_wrflowinp_nolake_roms_perf_rst.x || exit 8
+            $Couple_Lib_exec_coupler_Dir/uvoce_wrflowinp_nolake_perf_rst.x || exit 8
         else
             echo "no UaUo"
         fi

--- a/Shell/couple.sh
+++ b/Shell/couple.sh
@@ -154,14 +154,6 @@ time_start0=$(date "+%s")
 if [ $parameter_ROMS2WRF = yes ]; then
 echo "ROMS2WRF: NHour=$NHour, NLOOP=$NLOOP, $YYYYi:$MMi:$DDi:$HHi"
 
-        grep "failed" $logfile
-        if [ $? -eq 0 ]; then
-        echo "ERROR: reading or writing failed: ROMS2WRF.sh"
-        else
-        echo "no ERROR"
-        exit 8
-	    fi
-
 time_start=$(date "+%s")
 $Couple_Run_Dir/ROMS2WRF.sh $NHour $YYYYi:$MMi:$DDi:$HHi $YYYYin:$MMin:$DDin:$HHin $CF $NLOOP $NHourm || exit 8
 time_end=$(date "+%s")
@@ -181,14 +173,6 @@ echo "WW32WRF: NHour=$NHour, NLOOP=$NLOOP, $YYYYi:$MMi:$DDi:$HHi ~ $YYYYin:$MMin
 
 time_start=$(date "+%s")
 	$Couple_Run_Dir/WW32WRF.sh $NHour $NHourm $CF $NLOOP $YYYYin:$MMin:$DDin:$HHin  || exit 8
-
-        grep "failed" $logfile
-        if [ $? -eq 0 ]; then
-        echo "ERROR: reading or writing failed: WW32WRF.sh"
-        else
-        echo "no ERROR"
-        exit 8
-	    fi
 
 time_end=$(date "+%s")
 echo "WW32WRF = $((time_end-time_start))s" >> $Couple_Run_Dir/code_time

--- a/main_scripts/tutorial/tutorial1/submit_main_tutorial1_r01a_poseidon.sh
+++ b/main_scripts/tutorial/tutorial1/submit_main_tutorial1_r01a_poseidon.sh
@@ -27,4 +27,4 @@ dde=03
 hhe=00
 
 export logfile=$scoar_dir/tuto_r01_log_$$_$yyyye$mme$dde$hhe
-$scoar_dir/main_tutorial1_r01.sh $yyyye:$mme:$dde:$hhe $RESTART $LastNHour >& logfile
+$scoar_dir/main_tutorial1_r01.sh $yyyye:$mme:$dde:$hhe $RESTART $LastNHour >& $logfile


### PR DESCRIPTION
Calling `stop status` in the error handling subroutines returns an error code that invokes the `|| exit 8` statement in the shell scripts.